### PR TITLE
Fix key capability post, patch, response

### DIFF
--- a/definitions/control-v1.yaml
+++ b/definitions/control-v1.yaml
@@ -4008,10 +4008,11 @@ components:
           type: object
           additionalProperties:
             type: array
+            description: An array of strings setting the capability operations for the resource.
             items:
               type: string
       example:
-        name: string
+        name: My key name
         capability:
           channel1:
           - publish
@@ -4034,10 +4035,11 @@ components:
           type: object
           additionalProperties:
             type: array
+            description: An array of strings setting the capability operations for the resource.
             items:
               type: string
       example:
-        name: string
+        name: My key name
         capability:
           channel1:
           - publish
@@ -4068,6 +4070,7 @@ components:
           type: object
           additionalProperties:
             type: array
+            description: An array of strings setting the capability operations for the resource.
             items:
               type: string
           example:


### PR DESCRIPTION
## Description

When testing key creation it was noticed there was an error. This was due to an incorrect OAS3 spec being imported to Postman - the capablity arrangement for keys had been changed at some point and this was not reflected in this spec. This PR fixes the capability in the key_response, and also the request body sections for both key_post and key_patch.

* [JIRA ticket](https://ably.atlassian.net/browse/DOC-481)

## Checklist for OpenAPI document updates

Please ensure the following:

- [x] Version has been incremented
- [x] Tested for errors with Spectral
- [x] Optional: Load into SwaggerHub and check for errors
- [x] Ensure the document renders under ReDoc (see README for instructions on how to test locally)

## Review

* For this PR the best way is to check the diff. 
* Also check that the key section of the docs renders correctly locally.

