### PR TITLE
Add plain to sasl mechanism

### DIFF
--- a/definitions/.spectral.yaml
+++ b/definitions/.spectral.yaml
@@ -1,0 +1,14 @@
+rules:
+  oas3-api-servers:
+    description: "OpenAPI `servers` must be present and non-empty."
+    formats: ["oas3"]
+    given: "$"
+    then:
+      field: servers
+      function: schema
+      functionOptions:
+        schema:
+          items:
+            type: object
+          minItems: 1
+          type: array

--- a/definitions/control-v1.yaml
+++ b/definitions/control-v1.yaml
@@ -2,7 +2,7 @@
 openapi: 3.0.1
 info:
   title: Control API v1
-  version: 1.0.24
+  version: 1.0.25
   description: |
     Use the Control API to manage your applications, namespaces, keys, queues, rules, and more.
 
@@ -3609,6 +3609,7 @@ components:
                       description: The hash type to use. SCRAM supports either SHA-256 or SHA-512 hash functions.
                       example: 'scram-sha-256'
                       enum:
+                      - 'plain'
                       - 'scram-sha-256'
                       - 'scram-sha-512'
                     username:
@@ -3686,6 +3687,7 @@ components:
                       description: The hash type to use. SCRAM supports either SHA-256 or SHA-512 hash functions.
                       example: 'scram-sha-256'
                       enum:
+                      - 'plain'
                       - 'scram-sha-256'
                       - 'scram-sha-512'
                     username:
@@ -3779,6 +3781,7 @@ components:
                       description: The hash type to use. SCRAM supports either SHA-256 or SHA-512 hash functions.
                       example: 'scram-sha-256'
                       enum:
+                      - 'plain'
                       - 'scram-sha-256'
                       - 'scram-sha-512'
                     username:


### PR DESCRIPTION
## Description

Plain was added to sasl auth mechanism. 

This PR also adds a ruleset file that now seems to be required by spectral.

* [DOC-670](https://ably.atlassian.net/browse/DOC-670)

## Checklist for OpenAPI document updates

Please ensure the following:

- [x] Version has been incremented
- [x] Tested for errors with Spectral
- [ ] Optional: Load into SwaggerHub and check for errors
- [x] Ensure the document renders under ReDoc (see README for instructions on how to test locally)

## Review

Check Kafka rule mechanism now additionally supports `plain` as well as SCRAM.

![image](https://user-images.githubusercontent.com/25511700/154532693-630a0c02-356b-4676-b362-b1dab3e6bb2c.png)

