### PR TITLE
Doc 376 remove reactor references

### DIFF
--- a/definitions/control-v1.yaml
+++ b/definitions/control-v1.yaml
@@ -1350,7 +1350,7 @@ components:
             enveloped:
               type: boolean
               nullable: true
-              description: Delivered messaged are wrapped in an Ably envelope by default that contains metadata about the message and its payload. The form of the envelope depends on whether it is part of a Webhook/Function or a Queue/Firehose rule. For everything besides Webhooks, you can ensure you only get the raw payload by unchecking "Enveloped" when setting up the rule.
+              description: Delivered messages are wrapped in an Ably envelope by default that contains metadata about the message and its payload. The form of the envelope depends on whether it is part of a Webhook/Function or a Queue/Firehose rule. For everything besides Webhooks, you can ensure you only get the raw payload by unchecking "Enveloped" when setting up the rule.
               example: true
             format:
               type: string


### PR DESCRIPTION
## Description

Removed references to Reactor and updated links to direct to docs instead of Knowledge Base.

* [DOC-376](https://ably.atlassian.net/browse/DOC-376)

## Checklist for OpenAPI document updates

Please ensure the following:

- [x] Version has been incremented
- [x] Tested for errors with Spectral
- [ ] Optional: Load into SwaggerHub and check for errors
- [x] Ensure the document renders under ReDoc (see README for instructions on how to test locally)

## Review

Check to make sure all references to Reactor have been removed.