### PR TITLE
Improve the description of the app `status` property

### DIFF
--- a/definitions/control-v1.yaml
+++ b/definitions/control-v1.yaml
@@ -4477,7 +4477,7 @@ TOfReTlUQzgpXRW5h3n2LVXbXQhPGcVitb88Cm2R8cxQwgB1VncM8yvmKhREo2tz
           example: Default
         status:
           type: string
-          description: The application status. Disabled applications will not accept new connections and will return an error to all clients.
+          description: The status of the application. Can be enabled or disabled. Enabled means available to accept inbound connections and all services are available.
           example: enabled
         tlsOnly:
           type: boolean

--- a/definitions/control-v1.yaml
+++ b/definitions/control-v1.yaml
@@ -4477,7 +4477,7 @@ TOfReTlUQzgpXRW5h3n2LVXbXQhPGcVitb88Cm2R8cxQwgB1VncM8yvmKhREo2tz
           example: Default
         status:
           type: string
-          description: The status of the application. Can be enabled or disabled. Enabled means available to accept inbound connections and all services are available.
+          description: The status of the application. Can be `enabled` or `disabled`. Enabled means available to accept inbound connections and all services are available.
           example: enabled
         tlsOnly:
           type: boolean


### PR DESCRIPTION
## Description

At the moment descriptions of the `status` property are different for GET and POST methods, and the one for POST method is more descriptive. This change updates the description for the GET method accordingly.

I haven't ran the checks below as the change is quite small. Also, I wasn't sure if this should be edited directly in the yaml, or there is some other source of truth from which this yaml is generated - if that's the case please point me in the right direction and I will make the edit where needed. 

## Checklist for OpenAPI document updates

Please ensure the following:

- [ ] Version has been incremented
- [ ] Tested for errors with Spectral
- [ ] Optional: Load into SwaggerHub and check for errors
- [ ] Ensure the document renders under ReDoc (see README for instructions on how to test locally)

## Review

Instructions on how to review the PR.

